### PR TITLE
[ci] add EC CI, fix proofs to latest release

### DIFF
--- a/.github/workflows/easycrypt.yml
+++ b/.github/workflows/easycrypt.yml
@@ -1,0 +1,58 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  HOME: /home/charlie
+  OPAMYES: true
+  OPAMJOBS: 2
+
+jobs:
+  joc:
+    name: Check JoC-Style EC Examples
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/easycrypt/ec-build-box:release
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [common-joc, prf-joc, prg-joc]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install and Setup EasyCrypt
+      run: |
+        opam install --deps-only --depext-only --confirm-level=unsafe-yes easycrypt
+        opam install --deps-only easycrypt
+        opam install easycrypt
+        rm -f ~/.why3.conf
+        opam exec -- easycrypt why3config -why3 ~/.why3.conf
+    - name: Check JoC-style proof ${{ matrix.target }}
+      env:
+        TARGET: ${{ matrix.target }}
+      run: opam exec -- easycrypt runtest easycrypt.config
+
+  std:
+    name: Check idiomatic EC Examples
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/easycrypt/ec-build-box:release
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [prg-std]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install and Setup EasyCrypt
+      run: |
+        opam install --deps-only --depext-only --confirm-level=unsafe-yes easycrypt
+        opam install --deps-only easycrypt
+        opam install easycrypt
+        rm -f ~/.why3.conf
+        opam exec -- easycrypt why3config -why3 ~/.why3.conf
+    - name: Check idiomatic proof ${{ matrix.target }}
+      env:
+        TARGET: ${{ matrix.target }}
+      run: opam exec -- easycrypt runtest easycrypt.config ${{ matrix.target }}
+

--- a/PRF/easycrypt-joc/Cache.eca
+++ b/PRF/easycrypt-joc/Cache.eca
@@ -24,9 +24,13 @@ module type Cache = {
   include API
 }.
 
-module Eager (F : F) : Cache = {
+module Cache = {
   var cache : (int, t_out) fmap
-  
+}.
+
+module Eager (F : F) : Cache = {
+  include var Cache
+
   proc init() = {
     var r : t_out;
     var i : int;
@@ -48,7 +52,7 @@ module Eager (F : F) : Cache = {
 }.
 
 module Lazy (F : F) : Cache = {
-  var cache : (int, t_out) fmap
+  include var Cache
 
   proc init() = {
     F.init();
@@ -93,27 +97,14 @@ declare module F <: F { -Eager, -Lazy }.
 declare module A <: Adv { -F, -Eager, -Lazy }.
 
 module O (F : F) = {
-  proc e() = {
+  proc r() = {
     var i, r;
 
     i <- 0;
     while (i < max_compute) {
-      if (i \notin Eager.cache) {
+      if (i \notin Cache.cache) {
         r <@ F.compute();
-        Eager.cache.[i] <- r;
-      }
-      i <- i + 1;
-    }
-  }
-
-  proc l() = {
-    var i, r;
-
-    i <- 0;
-    while (i < max_compute) {
-      if (i \notin Lazy.cache) {
-        r <@ F.compute();
-        Lazy.cache.[i] <- r;
+        Cache.cache.[i] <- r;
       }
       i <- i + 1;
     }
@@ -121,35 +112,28 @@ module O (F : F) = {
 }.
 
 lemma swap_el: eager[ 
-  O(F).e();
+  O(F).r();
   , A(Eager(F)).run
 ~
   A(Lazy(F)).run,
-  O(F).l();
+  O(F).r();
 :
-={glob A, glob F} /\ ={cache}(Eager, Lazy)
+={glob A, glob F, Cache.cache}
 ==>
-={glob A, glob F, res} /\ ={cache}(Eager, Lazy)
+={glob A, glob F, res}
 ].
 proof.
-eager proc (v:
-  O(F).e(); ~ O(F).l(); :
-={glob F} /\ ={cache}(Eager, Lazy)
-==>
-={glob F} /\ ={cache}(Eager, Lazy))
-(={glob F} /\ ={cache}(Eager, Lazy)).
+eager proc (={glob F, Cache.cache})=> //.
 + by sim.
-+ auto.
-+ auto.
 + eager proc.
   inline.
   if {2}.
   - case (0 = max_compute).
-    + exfalso => /#.
+    + by exfalso => /#.
     splitwhile {1} ^while : i <= c.
     splitwhile {2} ^while{2} : i0 <= c.
-    seq 2 2 : ((={i, c, glob F} /\ (i = c + 1){1} /\ (0 <= c < max_compute){1} /\ ={cache}(Eager, Lazy) /\ (forall j, 0 <= j <= c => j \in Eager.cache){1})).
-    + sp; while (={i, c, glob F} /\ (0 <= i <= c + 1){1} /\ (0 <= c < max_compute){1} /\ ={cache}(Eager, Lazy) /\ (forall j, 0 <= j < i => j \in Eager.cache){1}).
+    seq 2 2 : ((={i, c, glob F, Cache.cache} /\ (i = c + 1){1} /\ (0 <= c < max_compute){1} /\ (forall j, 0 <= j <= c => j \in Cache.cache){1})).
+    + sp; while (={i, c, glob F, Cache.cache} /\ (0 <= i <= c + 1){1} /\ (0 <= c < max_compute){1} /\ (forall j, 0 <= j < i => j \in Cache.cache){1}).
       - if => //.
         + wp; call(: true).
           skip => />.
@@ -158,12 +142,12 @@ eager proc (v:
         smt().
       by skip => /#.
     sp; wp.
-    while (={c, glob F} /\ i{1} = i0{2} /\ ={cache}(Eager, Lazy) /\ (oget Eager.cache{1}.[c{1}] = result{2}) /\ (c \in Eager.cache){1}).
+    while (={c, glob F, Cache.cache} /\ i{1} = i0{2} /\ (oget Cache.cache{1}.[c{1}] = result{2}) /\ (c \in Cache.cache){1}).
     + if => //.
       + wp; call(: true); skip.
         smt(get_setE).
       wp; skip => /#.
-    while {2} (={c, glob F} /\ ={cache}(Eager, Lazy) /\ (0 <= i0 <= c + 1){2} /\ (forall j, 0 <= j <= c => j \in Lazy.cache){2}) (c{2} - i0{2} + 1).
+    while {2} (={c, glob F, Cache.cache} /\ (0 <= i0 <= c + 1){2} /\ (forall j, 0 <= j <= c => j \in Cache.cache){2}) (c{2} - i0{2} + 1).
     + move => &m z.
       rcondf ^if.
       + by skip => /#. 
@@ -171,13 +155,14 @@ eager proc (v:
     auto => />.
     smt().
   wp.
-  while (={c, glob F} /\ i{1} = i0{2} /\ !(0 <= c < max_compute){2} /\ ={cache}(Eager, Lazy) /\ (0 <= i{1}) /\ (oget Eager.cache{1}.[c{1}] = result{2})).
+  while (={c, glob F, Cache.cache} /\ i{1} = i0{2} /\ !(0 <= c < max_compute){2} /\ (0 <= i{1}) /\ (oget Cache.cache{1}.[c{1}] = result{2})).
     + if => //.
       + wp; call(: true); skip.
         smt(get_setE).
       wp; skip => /#.
   by wp; skip => />.
-by sim.
++ by sim.
++ by sim.
 qed.
 
 declare axiom F_ll: islossless F.compute.
@@ -187,7 +172,7 @@ proc.
 inline.
 replace * {2} { x } by {
   x;
-  O(F).l();
+  O(F).r();
 }; last first.
 + seq 3 3 : (#pre /\ ={b}); 1: by sim.
   inline.
@@ -198,13 +183,13 @@ replace * {2} { x } by {
     - smt().
     exact F_ll.
   by skip => /#.
-seq 2 2 : (={glob F, glob A} /\ ={cache}(Eager, Lazy) /\ Eager.cache{1} = empty).
+seq 2 2 : (={glob F, glob A, Cache.cache} /\ Cache.cache{1} = empty).
 + by wp; call(: true); auto. 
-transitivity* {1} { O(F).e(); b <@ A(Eager(F)).run(); }.
+transitivity* {1} { O(F).r(); b <@ A(Eager(F)).run(); }.
 + inline.
   sim 2 2.
   conseq />.
-  while (={Eager.cache, glob F} /\ i{1} = i0{2} /\ (forall j, i0 <= j => j \notin Eager.cache){2}).
+  while (={Cache.cache, glob F} /\ i{1} = i0{2} /\ (forall j, i0 <= j => j \notin Cache.cache){2}).
   + rcondt {2} ^if; 1: by auto => /#.
     wp; call (: true).
     auto => />.

--- a/PRF/easycrypt-joc/Sampling.eca
+++ b/PRF/easycrypt-joc/Sampling.eca
@@ -457,15 +457,15 @@ have eqv : equiv[Bound(L).sample ~ C_Red(C.Lazy(F(L))).sample:
   /\ Bound.cs{1} = PreSample.sample_index{2}
   /\ Bound.cs{2} <= Bound.cs{1}
   /\ 0 <= Bound.cs{1}
-  /\ (forall i, 0 <= i < PreSample.sample_index < max_samples => i \in C.Lazy.cache){2}
-  /\ (forall i, PreSample.sample_index <= i => i \notin C.Lazy.cache){2}
+  /\ (forall i, 0 <= i < PreSample.sample_index < max_samples => i \in C.Cache.cache){2}
+  /\ (forall i, PreSample.sample_index <= i => i \notin C.Cache.cache){2}
  ==>
   ={res, glob L} 
   /\ Bound.cs{1} = PreSample.sample_index{2}
   /\ Bound.cs{2} <= Bound.cs{1}
   /\ 0 <= Bound.cs{1}
-  /\ (forall i, 0 <= i < PreSample.sample_index < max_samples => i \in C.Lazy.cache){2}
-  /\ (forall i, PreSample.sample_index <= i => i \notin C.Lazy.cache){2}
+  /\ (forall i, 0 <= i < PreSample.sample_index < max_samples => i \in C.Cache.cache){2}
+  /\ (forall i, PreSample.sample_index <= i => i \notin C.Cache.cache){2}
 ].
 + proc; inline.
   sp.
@@ -476,8 +476,8 @@ have eqv : equiv[Bound(L).sample ~ C_Red(C.Lazy(F(L))).sample:
     + while {2} (
         (0 <= i <= c){2} 
         /\ (c = PreSample.sample_index){2}
-        /\ (forall i, 0 <= i < c => i \in C.Lazy.cache){2}
-        /\ (forall i, c <= i => i \notin C.Lazy.cache){2}
+        /\ (forall i, 0 <= i < c => i \in C.Cache.cache){2}
+        /\ (forall i, c <= i => i \notin C.Cache.cache){2}
         /\ (Bound.cs <= PreSample.sample_index){2}
         /\ ={glob L}
       ) (c - i){2}.
@@ -502,8 +502,8 @@ do 3! (call (:
   /\ Bound.cs{1} = PreSample.sample_index{2}
   /\ Bound.cs{2} <= Bound.cs{1}
   /\ 0 <= Bound.cs{1}
-  /\ (forall i, 0 <= i < PreSample.sample_index < max_samples => i \in C.Lazy.cache){2}
-  /\ (forall i, PreSample.sample_index <= i => i \notin C.Lazy.cache){2}
+  /\ (forall i, 0 <= i < PreSample.sample_index < max_samples => i \in C.Cache.cache){2}
+  /\ (forall i, PreSample.sample_index <= i => i \notin C.Cache.cache){2}
 ); first by conseq eqv).
 wp; call(: true).
 skip => />.
@@ -518,7 +518,7 @@ proof.
 byequiv => //.
 proc; inline.
 seq 9 9 : (={b}); last by islossless; exact L_fin_ll.
-sim (: ={glob L} /\ C.Eager.cache{1} = PreSample.samples{2} /\ ={PreSample.sample_index}).
+sim (: ={glob L} /\ C.Cache.cache{1} = PreSample.samples{2} /\ ={PreSample.sample_index}).
 by proc; inline; sim.
 qed.
 
@@ -944,19 +944,19 @@ proc.
 inline {1} 1; inline {2} 1.
 replace * {2} { x } by {
   x;
-  C.O(F(BDAY_uniq)).l();
+  C.O(F(BDAY_uniq)).r();
 }; last first.
 + seq 3 3: (#pre /\ ={b} /\ card BDAY_uniq.s{1} <= Bound.cs{1}).
   - conseq />.
     inline.
     have eqv : equiv[C_Red(C_Adv(A, C.Lazy(F(BDAY_uniq))).C').sample ~ C_Red(C_Adv(A, C.Lazy(F(BDAY_uniq))).C').sample:
-      ={arg, BDAY_uniq.s, Bound.cs, PreSample.sample_index, C.Lazy.cache} /\ card BDAY_uniq.s{1} <= Bound.cs{1}
+      ={arg, BDAY_uniq.s, Bound.cs, PreSample.sample_index, C.Cache.cache} /\ card BDAY_uniq.s{1} <= Bound.cs{1}
     ==>
-      ={res, BDAY_uniq.s, Bound.cs, PreSample.sample_index, C.Lazy.cache} /\ card BDAY_uniq.s{1} <= Bound.cs{1}
+      ={res, BDAY_uniq.s, Bound.cs, PreSample.sample_index, C.Cache.cache} /\ card BDAY_uniq.s{1} <= Bound.cs{1}
     ].
     + proc; inline.
       sp; if => //; 2: by auto.
-      wp; while (={i, c, C.Lazy.cache, Bound.cs, BDAY_uniq.s} /\ c{1} < max_samples /\ (0 <= i <= c + 1){1} /\ card BDAY_uniq.s{1} <= Bound.cs{1}).
+      wp; while (={i, c, C.Cache.cache, Bound.cs, BDAY_uniq.s} /\ c{1} < max_samples /\ (0 <= i <= c + 1){1} /\ card BDAY_uniq.s{1} <= Bound.cs{1}).
       + if; auto => />; last first.
         + smt().
         sp; if => //.
@@ -966,7 +966,7 @@ replace * {2} { x } by {
       by auto => /#.
     
     wp.
-    do 3! (call (: ={BDAY_uniq.s, Bound.cs, PreSample.sample_index, C.Lazy.cache} /\ card BDAY_uniq.s{1} <= Bound.cs{1}); first by conseq eqv).
+    do 3! (call (: ={BDAY_uniq.s, Bound.cs, PreSample.sample_index, C.Cache.cache} /\ card BDAY_uniq.s{1} <= Bound.cs{1}); first by conseq eqv).
     auto => />.
     smt(fcards0).
   inline.
@@ -977,13 +977,13 @@ replace * {2} { x } by {
     auto => />.
     smt(fcardU1 dt_excepted_ll).
   by skip => /#.
-seq 2 2 : (#pre /\ ={Bound.cs} /\ ={cache}(C.Eager, C.Lazy) /\ C.Eager.cache{1} = empty).
+seq 2 2 : (#pre /\ ={Bound.cs, C.Cache.cache} /\ C.Cache.cache{1} = empty).
 + by inline; auto. 
-transitivity* {1} { C.O(F(BDAY_uniq)).e(); b <@ C_Adv(A, C.Eager(F(BDAY_uniq))).run(); }.
+transitivity* {1} { C.O(F(BDAY_uniq)).r(); b <@ C_Adv(A, C.Eager(F(BDAY_uniq))).run(); }.
 + inline {2} 1.
   sim 2 2.
   conseq />.
-  while (={C.Eager.cache, Bound.cs, BDAY_uniq.s} /\ i{1} = i0{2} /\ (forall j, i0 <= j => j \notin C.Eager.cache){2}).
+  while (={C.Cache.cache, Bound.cs, BDAY_uniq.s} /\ i{1} = i0{2} /\ (forall j, i0 <= j => j \notin C.Cache.cache){2}).
   + rcondt {2} ^if; 1: by auto => /#.
     wp; call(: ={Bound.cs, BDAY_uniq.s}).
     + sim.

--- a/common/easycrypt-joc/Libraries.ec
+++ b/common/easycrypt-joc/Libraries.ec
@@ -2,6 +2,8 @@
 (* Library Building Blocks *)
 (* ------------------------------------------------------- *)
 require import AllCore.
+require        StdOrder.
+        import StdOrder.RealOrder.
 
 (* All libraries have an init and fin function *)
 module type LibBase = {
@@ -54,5 +56,5 @@ proof. by smt(). qed.
 (* Useful for up-to-bad impossible reasoning *)
 lemma abs_eq x y: `|x - y| <= 0%r => x = y.
 proof.
-by move => /normr_le0 /RField.subr_eq0.
+by move=> /normr_le0 /RField.subr_eq0.
 qed.

--- a/easycrypt.config
+++ b/easycrypt.config
@@ -1,0 +1,17 @@
+[default]
+bin    = easycrypt
+
+[test-all]
+okdirs = !.
+
+[test-common-joc]
+okdirs = common/easycrypt-joc
+
+[test-prf-joc]
+okdirs = PRF/easycrypt-joc
+
+[test-prg-std]
+okdirs = PRG/easycrypt
+
+[test-prg-joc]
+okdirs = PRG/easycrypt-joc

--- a/easycrypt.project
+++ b/easycrypt.project
@@ -1,0 +1,2 @@
+[general]
+provers = Z3@4.8


### PR DESCRIPTION
This adds EasyCrypt CI checks for the proofs on this ladder, and updates the proofs to work with the current release of EasyCrypt. (Using the `release` branch, which follows latest release.)

Doing this right so CI doesn't break unexpectedly on random pushes will require integration into EasyCrypt's external CI, to smooth out the management of breaking changes. 